### PR TITLE
Add ability to update room actions and other minor changes #17

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,12 @@
 -------------------------------------------------------------
+Next version
+
+- Added the ability to edit room actions and their tasks
+- Made room actions AC_STATE task dialogue slider
+  instantly reflect instead of waiting for movement to stop
+- Fixed edit room dialogue showing 'Add Room'
+
+-------------------------------------------------------------
 v0.4.1
 
 - Upgrade packages

--- a/src/api/actions.tsx
+++ b/src/api/actions.tsx
@@ -7,7 +7,12 @@ import {
 } from "@tanstack/react-query";
 import { AxiosError } from "axios";
 import { authenticated_api } from "./auth";
-import { RoomAction, RoomActionPost, TaskType } from "./schemas/actions";
+import {
+  RoomAction,
+  RoomActionPatch,
+  RoomActionPost,
+  TaskType,
+} from "./schemas/actions";
 
 const fetchRoomActions = (roomId?: string): Promise<RoomAction[]> => {
   return authenticated_api
@@ -41,6 +46,31 @@ export const useAddRoomAction = (): UseMutationResult<
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (roomAction: RoomActionPost) => postRoomAction(roomAction),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["RoomActions"] });
+    },
+  });
+};
+
+const patchRoomAction = (
+  action_id: string,
+  action: RoomActionPatch
+): Promise<RoomAction> => {
+  return authenticated_api
+    .patch(`/actions/room/${action_id}`, action)
+    .then((response) => response.data);
+};
+
+export const usePatchRoomAction = (): UseMutationResult<
+  RoomAction,
+  AxiosError,
+  { action_id: string; actionData: RoomActionPatch },
+  any
+> => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: { action_id: string; actionData: RoomActionPatch }) =>
+      patchRoomAction(data.action_id, data.actionData),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["RoomActions"] });
     },

--- a/src/api/schemas/actions.tsx
+++ b/src/api/schemas/actions.tsx
@@ -48,3 +48,10 @@ export interface RoomActionPost {
   icon: string;
   tasks: TaskPost[];
 }
+
+export interface RoomActionPatch {
+  name?: string;
+  room_id?: string;
+  icon?: string;
+  tasks?: TaskPost[];
+}

--- a/src/components/devices/ACController.tsx
+++ b/src/components/devices/ACController.tsx
@@ -96,15 +96,22 @@ export const ACController = (props: ACControllerProps) => {
           max={30}
           step={1}
           {...(props.useInternalState
-            ? { value: props.deviceState.target_temperature }
-            : { defaultValue: props.deviceState.target_temperature })}
+            ? {
+                value: props.deviceState.target_temperature,
+                onChange: (event, value) =>
+                  handleStateChange({
+                    target_temperature: Array.isArray(value) ? value[0] : value,
+                  }),
+              }
+            : {
+                defaultValue: props.deviceState.target_temperature,
+                onChangeCommitted: (event, value) =>
+                  handleStateChange({
+                    target_temperature: Array.isArray(value) ? value[0] : value,
+                  }),
+              })}
           marks
           valueLabelDisplay="auto"
-          onChangeCommitted={(event, value) =>
-            handleStateChange({
-              target_temperature: Array.isArray(value) ? value[0] : value,
-            })
-          }
         />
       </Grid>
       <Grid item>

--- a/src/components/rooms/AdminRoomActionsAccordion.tsx
+++ b/src/components/rooms/AdminRoomActionsAccordion.tsx
@@ -15,6 +15,7 @@ import { Room } from "../../api/schemas/rooms";
 import { CircularLoadingIndicator } from "../CircularLoadingIndicator";
 import { ICONS } from "./Actions";
 import { RoomActionDialog } from "./RoomActionDialog";
+import EditIcon from "@mui/icons-material/Edit";
 
 interface AdminRoomActionsAccordionProps {
   room: Room;
@@ -64,10 +65,16 @@ export const AdminRoomActionsAccordion = (
               >
                 {ICONS[action.icon]}
                 <Typography sx={{ marginLeft: 0.5 }}>{action.name}</Typography>
-                <IconButton
-                  sx={{ marginLeft: "auto" }}
-                  onClick={() => handleDeleteClicked(action.id)}
-                >
+                <RoomActionDialog
+                  renderButton={(onClick) => (
+                    <IconButton sx={{ marginLeft: "auto" }} onClick={onClick}>
+                      <EditIcon />
+                    </IconButton>
+                  )}
+                  room={props.room}
+                  existingData={action}
+                />
+                <IconButton onClick={() => handleDeleteClicked(action.id)}>
                   <DeleteIcon color="error" />
                 </IconButton>
               </Card>

--- a/src/components/rooms/RoomDialog.tsx
+++ b/src/components/rooms/RoomDialog.tsx
@@ -43,9 +43,9 @@ export const RoomDialog = (props: RoomDialogProps) => {
 
   // Assign room when updated (when editing)
   useEffect(() => {
-    if (props.existingData !== undefined)
+    if (open && props.existingData !== undefined)
       setRoom(props.existingData as RoomPost);
-  }, [props.existingData]);
+  }, [open, props.existingData]);
 
   // Mutations
   const roomAddMutation = useAddRoom();
@@ -195,7 +195,9 @@ export const RoomDialog = (props: RoomDialogProps) => {
     <>
       {props.renderButton(() => setOpen(true))}
       <Dialog open={open} onClose={handleClose} maxWidth="md" fullWidth>
-        <DialogTitle>Add Room</DialogTitle>
+        <DialogTitle>
+          {props.existingData ? "Edit Room" : "Add Room"}
+        </DialogTitle>
         <DialogContent>
           <Stepper activeStep={activeStep} sx={{ marginBottom: 4 }}>
             {ADD_DIALOGUE_STEPS.map((label, index) => (


### PR DESCRIPTION
- Added the ability to edit room actions and their tasks
- Made room actions AC_STATE task dialogue slider
  instantly reflect instead of waiting for movement to stop
- Fixed edit room dialogue showing 'Add Room'

Closes #17